### PR TITLE
Changing events fired when filling form inputs

### DIFF
--- a/fill.js
+++ b/fill.js
@@ -27,7 +27,7 @@ chrome.runtime.onMessage.addListener(function(response, sender, sendResponse){
                     field.value = option.value;
 
                     // make sure we dispatch a native DOM change event later
-                    fireChangeEvent = false
+                    fireChangeEvent = true;
                 } else {
                     field.value = response[property];
                 }

--- a/fill.js
+++ b/fill.js
@@ -3,6 +3,7 @@ chrome.runtime.onMessage.addListener(function(response, sender, sendResponse){
         for (var property in response) {
             if (response.hasOwnProperty(property)) {
                 var field = document.getElementById(property);
+                var fireChangeEvent = false;
 
                 // deal with selects
                 if (field.nodeName === 'SELECT') {
@@ -25,12 +26,18 @@ chrome.runtime.onMessage.addListener(function(response, sender, sendResponse){
                     //update the value
                     field.value = option.value;
 
+                    // make sure we dispatch a native DOM change event later
+                    fireChangeEvent = false
                 } else {
                     field.value = response[property];
                 }
 
-                // dispatch a native DOM change event
-                field.dispatchEvent(new Event('change'));
+                // dispatch event(s)
+                field.dispatchEvent(new Event('input', {'bubbles': true}));
+
+                if (fireChangeEvent) {
+                    field.dispatchEvent(new Event('change', {'bubbles': true}));
+                }
             }
         }
     })

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Fire Engine RED Chrome Tools",
   "description": "Autofill PR template for FER Repo's, simplifies QA testing of the Fireworks CRM by automatically entering dummy data.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "background" : {
       "scripts" : ["background.js"]
   },
@@ -15,7 +15,7 @@
       "38": "images/icon38.png"
     },
     "default_title": "FER Chrome Tools",
-    "default_popup": "popup.html"    
+    "default_popup": "popup.html"
   },
   "icons": {
       "19": "images/icon.png",


### PR DESCRIPTION
The `change` event is as universally functional as the `input` event for our use case. We are still _also_ firing a `change` event for selects, because the JS world listens to change events for that type of element more often for additional functionality.